### PR TITLE
[arm64] config: disable /dev/mem device

### DIFF
--- a/debian/config/arm64/config
+++ b/debian/config/arm64/config
@@ -92,6 +92,11 @@ CONFIG_HISILICON_LPC=y
 CONFIG_TEGRA_ACONNECT=y
 
 ##
+## file: drivers/char/Kconfig
+##
+# CONFIG_DEVMEM is not set
+
+##
 ## file: drivers/char/hw_random/Kconfig
 ##
 CONFIG_HW_RANDOM_BCM2835=m


### PR DESCRIPTION
Fix https://bugs.linaro.org/show_bug.cgi?id=3081

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>