### PR TITLE
config/arm64 add CPPC cpufreq driver

### DIFF
--- a/debian/config/arm64/config
+++ b/debian/config/arm64/config
@@ -144,6 +144,11 @@ CONFIG_MSM_MMCC_8996=y
 CONFIG_CPUFREQ_DT=m
 
 ##
+## file: drivers/cpufreq/Kconfig.arm
+##
+CONFIG_ACPI_CPPC_CPUFREQ=y
+
+##
 ## file: drivers/cpuidle/Kconfig.arm
 ##
 CONFIG_ARM_CPUIDLE=y


### PR DESCRIPTION
CPPC is the only cpufreq driver currently supported on arm64 ACPI, enable it so platforms with correct DSDT can make use of it.

Signed-off-by: Graeme Gregory <graeme.gregory@linaro.org>