### PR TITLE
Enable Socionext NetSec driver as a module

### DIFF
--- a/debian/config/arm64/config
+++ b/debian/config/arm64/config
@@ -566,6 +566,12 @@ CONFIG_EPIC100=m
 CONFIG_SMSC911X=m
 
 ##
+## file: drivers/net/ethernet/socionext/Kconfig
+##
+CONFIG_NET_VENDOR_SNI=y
+CONFIG_SNI_NETSEC=m
+
+##
 ## file: drivers/net/ethernet/stmicro/stmmac/Kconfig
 ##
 CONFIG_STMMAC_ETH=m


### PR DESCRIPTION
Signed-off-by: Ard Biesheuvel <ard.biesheuvel@linaro.org>