### PR TITLE
disable code signing to enable udebs

### DIFF
--- a/debian/config/amd64/defines
+++ b/debian/config/amd64/defines
@@ -7,7 +7,7 @@ kernel-arch: x86
 [build]
 debug-info: true
 image-file: arch/x86/boot/bzImage
-signed-code: true
+signed-code: false
 vdso: true
 
 [image]

--- a/debian/config/arm64/defines
+++ b/debian/config/arm64/defines
@@ -7,7 +7,7 @@ featuresets:
 [build]
 debug-info: true
 image-file: arch/arm64/boot/Image
-signed-code: true
+signed-code: false
 vdso: true
 
 [image]


### PR DESCRIPTION
Apparently enabling code signing disables udeb building.