### PR TITLE
4.19.4 and graphics for d-i

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,11 @@
-linux (4.19.3-1~exp1) UNRELEASED; urgency=medium
+linux (4.19.4-1~exp1) UNRELEASED; urgency=medium
 
   * New upstream release: https://kernelnewbies.org/Linux_4.19
   * New upstream stable update:
     https://www.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.19.1
     https://www.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.19.2
     https://www.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.19.3
+    https://www.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.19.4
 
   [ Ben Hutchings ]
   * linux-perf: Enable verbose output for build-time feature detection

--- a/debian/changelog
+++ b/debian/changelog
@@ -24,6 +24,7 @@ linux (4.19.4-1~exp1) UNRELEASED; urgency=medium
   [ Uwe Kleine-König ]
   * [armhf,arm64] enable SND_BCM2835 as a module (Closes: #911121)
   * Enable Orange filesystem (Closes: #911743)
+  * [arm64] Enable hns3 network driver as a module.
 
   [ Noah Meyerhans ]
   * [cloud-amd64] Enable Amazon ENA ethernet driver (Closes: #910049)

--- a/debian/changelog
+++ b/debian/changelog
@@ -24,8 +24,7 @@ linux (4.19.4-1~exp1) UNRELEASED; urgency=medium
   [ Uwe Kleine-König ]
   * [armhf,arm64] enable SND_BCM2835 as a module (Closes: #911121)
   * Enable Orange filesystem (Closes: #911743)
-  * [arm64] Enable hns3 network driver as a module.
-  * [arm64] Add hisilicon drivers to the nic-modules udeb. (Closes: #914422)
+  * [arm64] Enable hns3 network driver as a module. (Closes: #914422)
 
   [ Noah Meyerhans ]
   * [cloud-amd64] Enable Amazon ENA ethernet driver (Closes: #910049)

--- a/debian/changelog
+++ b/debian/changelog
@@ -25,6 +25,7 @@ linux (4.19.4-1~exp1) UNRELEASED; urgency=medium
   * [armhf,arm64] enable SND_BCM2835 as a module (Closes: #911121)
   * Enable Orange filesystem (Closes: #911743)
   * [arm64] Enable hns3 network driver as a module.
+  * [arm64] Add hisilicon drivers to the nic-modules udeb. (Closes: #914422)
 
   [ Noah Meyerhans ]
   * [cloud-amd64] Enable Amazon ENA ethernet driver (Closes: #910049)

--- a/debian/installer/modules/arm64/nic-modules
+++ b/debian/installer/modules/arm64/nic-modules
@@ -7,14 +7,6 @@ stmmac-platform
 dwmac-generic
 dwmac-ipq806x
 xgene-enet
-hns_mdio
-hnae
-hns_dsaf
-hns_enet_drv
-hns3
-hclge
-hclgevf
-hnae3
 nicpf ?
 nicvf ?
 thunder_bgx ?

--- a/debian/installer/modules/arm64/nic-modules
+++ b/debian/installer/modules/arm64/nic-modules
@@ -7,6 +7,3 @@ stmmac-platform
 dwmac-generic
 dwmac-ipq806x
 xgene-enet
-nicpf ?
-nicvf ?
-thunder_bgx ?

--- a/debian/installer/modules/virtio-modules
+++ b/debian/installer/modules/virtio-modules
@@ -4,6 +4,7 @@ virtio_balloon
 virtio_scsi
 virtio_input
 virtio_console
+virtio-gpu
 
 # Some architectures do not have PCI bus
 virtio_pci ?

--- a/debian/installer/package-list
+++ b/debian/installer/package-list
@@ -359,7 +359,7 @@ Description: RTC modules
  This package contains RTC modules.
 
 Package: virtio-modules
-Depends: kernel-image, scsi-core-modules
+Depends: kernel-image, scsi-core-modules, fb-modules
 Priority: optional
 Description: virtio modules
  This package contains virtio modules.


### PR DESCRIPTION
After discussions with Debian kernel people I got some changes:

- hns3 driver for D06 enabled in Debian
- removed our listing of Ethernet drivers from d-i/nic-modules as all Ethernet drivers go there anyway
- enabled virtio-gpu for d-i so we get graphics in VM