### PR TITLE
Config cleanup again

### DIFF
--- a/debian/config/arm64/config
+++ b/debian/config/arm64/config
@@ -219,12 +219,6 @@ CONFIG_TEGRA210_ADMA=y
 CONFIG_XGENE_DMA=m
 
 ##
-## file: drivers/dma/dw/Kconfig
-##
-CONFIG_DW_DMAC=m
-CONFIG_DW_DMAC_PCI=m
-
-##
 ## file: drivers/dma/qcom/Kconfig
 ##
 CONFIG_QCOM_BAM_DMA=m

--- a/debian/config/arm64/config
+++ b/debian/config/arm64/config
@@ -88,7 +88,7 @@ CONFIG_ACPI_APEI_EINJ=m
 ##
 ## file: drivers/android/Kconfig
 ##
-# CONFIG_ANDROID is not set
+CONFIG_ANDROID=y
 
 ##
 ## file: drivers/ata/Kconfig


### PR DESCRIPTION
CONFIG_ANDROID is there to enable some binder related modules

CONFIG_DW_DMAC may or may not be needed for our targets.