### PR TITLE
Linaro: kernel-image provides virtio-modules

### DIFF
--- a/debian/installer/package-list
+++ b/debian/installer/package-list
@@ -4,7 +4,8 @@
 #
 Package: kernel-image
 Provides_amd64: zlib-modules
-Provides_arm64: mmc-core-modules, zlib-modules
+# we use Buster kernel with Stretch d-i (which needs virtio-modules)
+Provides_arm64: mmc-core-modules, zlib-modules, virtio-modules
 Provides_armel: rtc-modules
 Provides_armmp: mmc-core-modules, mtd-core-modules
 Provides_i386: rtc-modules, zlib-modules


### PR DESCRIPTION
In Buster this udeb is no more present as it's content got spread info
already existing udebs (scsi, nic, fb etc).

Stretch d-i expects this udeb to be present. So instead of reverting
changes we just provide it with 'kernel-image' udeb.